### PR TITLE
特殊文字や全角文字を、半角文字やエスケープシーケンスに置き換える

### DIFF
--- a/main.c
+++ b/main.c
@@ -6,23 +6,23 @@
 #include <wchar.h>
 
 char roboks[] =
-    R"(    w\
-     \          y>/一\<w
-      \         y/ヽ_ノヽw
-       \           yﾊw
-        \       c———————w
-         \.  c／         ＼w
-           c／  w●c       w●c  ＼w
-          c/     w❘ニニニ❘c     c\w
-        c／|—————————————————|ヽw
-       c/ /b|    g〇 y〇 m〇     b|ヽヽw
-     r(一) b|                 | r(一)w
-          b|     y／一＼      b|
-          b|     y| ?  |      b|
-          b|     y＼一／      b|
-          b|＿  ＿＿＿＿  ＿.|
-             cΠ         Π   
-        r(ニニ|         |ニニ)d)";
+    "    w\\\n"
+    "     \\          y>/一<\\w\n"
+    "      \\         y/ヽ_ノヽw\n"
+    "       \\           yﾊw\n"
+    "        \\       c———————w\n"
+    "         \\.  c／         ＼w\n"
+    "           c／  w●c       w●c  ＼w\n"
+    "          c/     w❘ニニニ❘c     c\\w\n"
+    "        c／|—————————————————|ヽw\n"
+    "       c/ /b|    g〇 y〇 m〇     b|ヽヽw\n"
+    "     r(一) b|                 | r(一)w\n"
+    "          b|     y／一＼      b|\n"
+    "          b|     y| ?  |      b|\n"
+    "          b|     y＼一／      b|\n"
+    "          b|＿  ＿＿＿＿  ＿.|\n"
+    "             cΠ         Π   \n"
+    "        r(ニニ|         |ニニ)d)";
 
 int mb_strlen( const char* str ) {
     setlocale( LC_ALL, "" );


### PR DESCRIPTION
## 概要
後述するバージョンのMacOSとgccでエラーが発生しました．
解決策として特殊文字や全角文字を、半角文字やエスケープシーケンスに置き換える方法を提案します．

## エラーが発生するバージョン
- 以下のバージョンのMacOS, gccでエラーが発生しました
MacOSのバージョン
```shell
OS: macOS Sonoma 14.4.1 arm64
```

gccのバージョン
```shell
gcc --version
Apple clang version 15.0.0 (clang-1500.3.9.4)
Target: arm64-apple-darwin23.4.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

## エラー内容
特殊文字や全角文字によってCコンパイラが解釈できずエラーになっているものと思われます．

```shell
gcc main.c -o robokssay
main.c:9:6: warning: missing terminating '"' character [-Winvalid-pp-token]
    R"(    w\
     ^
main.c:9:5: error: use of undeclared identifier 'R'
    R"(    w\
    ^
main.c:9:6: error: expected ';' after top level declarator
    R"(    w\
     ^
     ;
main.c:13:18: error: character <U+2014> not allowed in an identifier
        \       c———————w
                 ^
main.c:13:21: error: character <U+2014> not allowed in an identifier
        \       c———————w
                  ^
main.c:13:24: error: character <U+2014> not allowed in an identifier
        \       c———————w
                   ^
main.c:13:27: error: character <U+2014> not allowed in an identifier
        \       c———————w
                    ^
main.c:13:30: error: character <U+2014> not allowed in an identifier
        \       c———————w
                     ^
main.c:13:33: error: character <U+2014> not allowed in an identifier
        \       c———————w
                      ^
main.c:13:36: error: character <U+2014> not allowed in an identifier
        \       c———————w
                       ^
main.c:14:15: warning: treating Unicode character <U+FF0F> as identifier character rather than as '/' symbol [-Wunicode-homoglyph]
         \.  c／         ＼w
              ^~
main.c:14:27: warning: treating Unicode character <U+FF3C> as identifier character rather than as '\' symbol [-Wunicode-homoglyph]
         \.  c／         ＼w
                         ^~
main.c:15:13: warning: treating Unicode character <U+FF0F> as identifier character rather than as '/' symbol [-Wunicode-homoglyph]
           c／  w●c       w●c  ＼w
            ^~
main.c:15:19: error: character <U+25CF> not allowed in an identifier
           c／  w●c       w●c  ＼w
                 ^
main.c:15:31: error: character <U+25CF> not allowed in an identifier
           c／  w●c       w●c  ＼w
                           ^
main.c:15:37: warning: treating Unicode character <U+FF3C> as identifier character rather than as '\' symbol [-Wunicode-homoglyph]
           c／  w●c       w●c  ＼w
                               ^~
main.c:16:19: error: character <U+2758> not allowed in an identifier
          c/     w❘ニニニ❘c     c\w
                  ^
main.c:16:31: error: character <U+2758> not allowed in an identifier
          c/     w❘ニニニ❘c     c\w
                         ^
main.c:17:10: warning: treating Unicode character <U+FF0F> as identifier character rather than as '/' symbol [-Wunicode-homoglyph]
        c／|—————————————————|ヽw
         ^~
main.c:17:14: error: unexpected character <U+2014>
        c／|—————————————————|ヽw
            ^
main.c:17:17: error: unexpected character <U+2014>
        c／|—————————————————|ヽw
             ^
main.c:17:20: error: unexpected character <U+2014>
        c／|—————————————————|ヽw
              ^
main.c:17:23: error: unexpected character <U+2014>
        c／|—————————————————|ヽw
               ^
main.c:17:26: error: unexpected character <U+2014>
        c／|—————————————————|ヽw
                ^
main.c:17:29: error: unexpected character <U+2014>
        c／|—————————————————|ヽw
                 ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
6 warnings and 20 errors generated.
```

## 対応と解決策
ASCII文字に置き換えることによって解決します．


```c
gcc main.c -o robokssay
./robokssay
  ---------------------
＜ 踏めば助かるのに... ＞
  ---------------------
   \
     \          >/一<\
      \         /ヽ_ノヽ
       \           ﾊ
        \       ———————
         \.  ／         ＼
           ／  ●       ●  ＼
          /     ❘ニニニ❘     \
        ／|—————————————————|ヽ
       / /|    〇 〇 〇     |ヽヽ
     (一) |                 | (一)
          |     ／一＼      |
          |     | ?  |      |
          |     ＼一／      |
          |＿  ＿＿＿＿  ＿.|
             Π         Π
```