### PR TITLE
Nixでの実行をサポートします

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,13 @@ docker build . -t robokssay
 docker run robokssay robokssay
 ```
 
+### Nixを使って実行する場合
+
+実行は以下のようにします。
+
+```bash
+nix run github:7-rate/robokssay#robokssay
+```
+
 ## Result Example
 ![result](docs/image.png)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,58 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1715865404,
+        "narHash": "sha256-/GJvTdTpuDjNn84j82cU6bXztE0MSkdnTWClUCRub78=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8dc45382d5206bd292f9c2768b8058a8fd8311d9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1716948383,
+        "narHash": "sha256-SzDKxseEcHR5KzPXLwsemyTR/kaM9whxeiJohbL04rs=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ad57eef4ef0659193044870c731987a6df5cf56b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1714640452,
+        "narHash": "sha256-QBx10+k6JWz6u7VsohfSw8g8hjdBZEf8CFzXH1/1Z94=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
 
   outputs = inputs@{ flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } (_: {
-      systems = [ "aarch64-darwin" ];
+      systems =  [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       perSystem = { self', pkgs, lib, ... }: {
         packages.robokssay = pkgs.stdenv.mkDerivation {
           name = "robokssay";

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  description = "「踏めば助かるのに...」でおなじみのロボカスに何でも言わせる";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } (_: {
+      systems = [ "aarch64-darwin" ];
+      perSystem = { self', pkgs, lib, ... }: {
+        packages.robokssay = pkgs.stdenv.mkDerivation {
+          name = "robokssay";
+          src = lib.cleanSource ./.;
+          buildPhase = ''
+            $CC main.c -o robokssay
+          '';
+          installPhase = ''
+            mkdir -p $out/bin
+            cp robokssay $out/bin
+          '';
+        };
+        apps.robokssay = {
+          type = "app";
+          program = "${self'.packages.robokssay}/bin/robokssay";
+        };
+      };
+    });
+}


### PR DESCRIPTION
## 概要

[Nix](https://nixos.org/) での実行をサポートします。

手元にDockerの環境が無かったので追加しました。

## 備考

READMEに記載の方法はgithubのユーザ名とリポジトリ名を指定する方法 (ブランチ名を省略するとデフォルトブランチが利用される) になっているので実際に動作確認はできていません。
PRの作成用にフォークしたリポジトリとブランチ (support-nix) での実行結果は以下です。

```shell
❯❯❯ nix run github:ttak0422/robokssay/support-nix#robokssay
  ---------------------
＜ 踏めば助かるのに... ＞
  ---------------------
   \
     \          >/一<\
      \         /ヽ_ノヽ
       \           ﾊ
        \       ———————
         \.  ／         ＼
           ／  ●       ●  ＼
          /     ❘ニニニ❘     \
        ／|—————————————————|ヽ
       / /|    〇 〇 〇     |ヽヽ
     (一) |                 | (一)
          |     ／一＼      |
          |     | ?  |      |
          |     ＼一／      |
          |＿  ＿＿＿＿  ＿.|
             Π         Π
        (ニニ|         |ニニ))
 ```